### PR TITLE
fix bug that was causing mappings to map to the wrong file

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,11 @@ function merge(oldMap, newMap) {
   })
 
   var mergedMap = JSON.parse(mergedMapGenerator.toString())
-  mergedMap.sources = oldMap.sources
-  mergedMap.sourcesContent = oldMap.sourcesContent
+
+  mergedMap.sourcesContent = mergedMap.sources.map(function (source) {
+    return oldMapConsumer.sourceContentFor(source)
+  })
+
   mergedMap.sourceRoot = oldMap.sourceRoot
 
   return mergedMap


### PR DESCRIPTION
When merging source maps, we were replacing the new sources list by the old one.
This was causing the mappings to be pointing to the wrong index in the sources array.